### PR TITLE
Update CreationKitUnitConverter.cs

### DIFF
--- a/Metric-Units/CreationKitUnitConverter.cs
+++ b/Metric-Units/CreationKitUnitConverter.cs
@@ -32,7 +32,7 @@ namespace MetricUnits
         private string? Exec(string arguments)
         {
             using Process ckconv = new();
-            ckconv.StartInfo.FileName = executable_name;
+            ckconv.StartInfo.FileName = path;
             ckconv.StartInfo.Arguments = arguments;
             ckconv.StartInfo.UseShellExecute = false;
             ckconv.StartInfo.RedirectStandardOutput = true;


### PR DESCRIPTION
Fix for System.ComponentModel.Win32Exception (2): The system cannot find the file specified. since Synthesis is trying to find ckconv.exe in the working folder, rather than by full path